### PR TITLE
Add default CMAKE_BUILD_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,15 @@ add_install_rpath_support(BIN_DIRS "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BIND
                           DEPENDS ENABLE_RPATH
                           USE_LINK_PATH)
 
+# Encourage user to specify a build type (e.g. Release, Debug, etc.),
+# otherwise set it to Release.
+if(NOT CMAKE_CONFIGURATION_TYPES)
+    if(NOT CMAKE_BUILD_TYPE)
+        message(STATUS "Setting build type to 'Release' as none was specified.")
+        set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
+    endif()
+endif()
+
 ### Compile- and install-related commands
 add_subdirectory(src)
 


### PR DESCRIPTION
As you suggest in #12 I added a default CMAKE_BUILD_TYPE.
Default value, if not set by the user, is Release.

Fixes #12