### PR TITLE
Change executables and library build folders to fix ctests on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,6 +5,7 @@ clone_folder: c:\dev\lib-template-cmake
 os:
     - Visual Studio 2013
     - Visual Studio 2015
+    - Visual Studio 2017
 
 install:
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,6 @@ after_build:
     # Install only release
     - cmake --build C:\dev\lib-template-cmake\build --config Release --target INSTALL
 
-# For some reason, tests are not working. Debug this and enable them again
-# test_script:
-#    - ctest -C Debug -VV
-#    - ctest -C Release -VV
+test_script:
+    - ctest -C Debug -VV
+    - ctest -C Release -VV

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,14 +19,14 @@ endif()
 ###
 
 # This sets the PROJECT_NAME, PROJECT_VERSION as well as other variable
-# listed here: https://cmake.org/cmake/help/latest/command/project.html
+# listed here: https://cmake.org/cmake/help/latest/command/project.html.
 # We use this name to export all the files such that is then possible to use
 # find_package(LibTemplateCMake) in third party projects.
 project(LibTemplateCMake
         LANGUAGES CXX
         VERSION 0.0.0.0)
 
-# Defines the CMAKE_INSTALL_LIBDIR, CMAKE_INSTALL_BINDIR and many other useful macros
+# Defines the CMAKE_INSTALL_LIBDIR, CMAKE_INSTALL_BINDIR and many other useful macros.
 # See https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
 include(GNUInstallDirs)
 
@@ -41,7 +41,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}"
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
 
-# To build shared libraries in Windows, we set CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS to TRUE
+# To build shared libraries in Windows, we set CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS to TRUE.
 # See https://cmake.org/cmake/help/v3.4/variable/CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.html
 # See https://blog.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
@@ -74,8 +74,7 @@ add_install_rpath_support(BIN_DIRS "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BIND
                           DEPENDS ENABLE_RPATH
                           USE_LINK_PATH)
 
-# Encourage user to specify a build type (e.g. Release, Debug, etc.),
-# otherwise set it to Release.
+# Encourage user to specify a build type (e.g. Release, Debug, etc.), otherwise set it to Release.
 if(NOT CMAKE_CONFIGURATION_TYPES)
     if(NOT CMAKE_BUILD_TYPE)
         message(STATUS "Setting build type to 'Release' as none was specified.")
@@ -83,7 +82,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES)
     endif()
 endif()
 
-### Compile- and install-related commands
+### Compile- and install-related commands.
 add_subdirectory(src)
 
 # Create and install CMake configuration files for your project that are
@@ -106,7 +105,7 @@ install_basic_package_files(${PROJECT_NAME}
 # Add the uninstall target
 include(AddUninstallTarget)
 
-# Add integration tests (unit tests for each library should be in each sublibrary directory)
+# Add integration tests (unit tests for each library should be in each sublibrary directory).
 if(BUILD_TESTING)
     add_subdirectory(test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,17 @@ project(LibTemplateCMake
 # See https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
 include(GNUInstallDirs)
 
+# Control where libraries and executables are placed during the build.
+# With the following settings executables are placed in <the top level of the
+# build tree>/bin and libraries/archives in <top level of the build tree>/lib.
+# This is particularly useful to run ctests on libraries built on Windows
+# machines: tests, which are executables, are placed in the same folders of
+# dlls, which are treated as executables as well, so that they can properly
+# find the libraries to run. This is a because of missing RPATH on Windows.
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+
 # To build shared libraries in Windows, we set CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS to TRUE
 # See https://cmake.org/cmake/help/v3.4/variable/CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.html
 # See https://blog.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/

--- a/src/LibTemplateCMake/CMakeLists.txt
+++ b/src/LibTemplateCMake/CMakeLists.txt
@@ -4,12 +4,12 @@
 # lib<LIBRARY_TARGET_NAME>.dylib or <LIBRARY_TARGET_NAME>.lib.
 set(LIBRARY_TARGET_NAME LibTemplateCMake)
 
-# List of CPP (source) library files
+# List of CPP (source) library files.
 set(${LIBRARY_TARGET_NAME}_SRC
         src/LibTemplateCMake.cpp
 )
 
-# List of HPP (header) library files
+# List of HPP (header) library files.
 set(${LIBRARY_TARGET_NAME}_HDR
         include/LibTemplateCMake/LibTemplateCMake.h
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,4 +14,6 @@ target_link_libraries(${TEST_TARGET_NAME} LibTemplateCMake)
 # COMMAND tag specifies the test command-line. If it is an executable target
 # created by add_executable(), it will automatically be replaced by the location
 # of the executable created at build time.
-add_test(NAME ${TEST_TARGET_NAME} COMMAND ${TEST_TARGET_NAME})
+add_test(NAME ${TEST_TARGET_NAME}
+         COMMAND ${TEST_TARGET_NAME}
+         WORKING_DIRECTORY $<TARGET_FILE_DIR:${TEST_TARGET_NAME}>)


### PR DESCRIPTION
The main changes are in the main [CMakeLists](https://github.com/robotology/how-to-export-cpp-library/compare/master...claudiofantacci:fix/outputdir?expand=1#diff-af3b638bc2a3e6c650974192a53c7291).

I enabled ctest and added Visual Studio 2017 build system on AppVeyor.